### PR TITLE
Prevent internal server error when receiving a JSON request body with non-object top-level structure

### DIFF
--- a/aiohttp_pydantic/__init__.py
+++ b/aiohttp_pydantic/__init__.py
@@ -1,5 +1,5 @@
 from .view import PydanticView
 
-__version__ = "1.7.2"
+__version__ = "1.7.3"
 
 __all__ = ("PydanticView", "__version__")

--- a/aiohttp_pydantic/__init__.py
+++ b/aiohttp_pydantic/__init__.py
@@ -1,5 +1,5 @@
 from .view import PydanticView
 
-__version__ = "1.7.3"
+__version__ = "1.8.0"
 
 __all__ = ("PydanticView", "__version__")

--- a/aiohttp_pydantic/injectors.py
+++ b/aiohttp_pydantic/injectors.py
@@ -69,6 +69,10 @@ class BodyGetter(AbstractInjector):
             raise HTTPBadRequest(
                 text='{"error": "Malformed JSON"}', content_type="application/json"
             ) from None
+        if not type(body) == dict:
+            raise HTTPBadRequest(
+                text='{"error": "Malformed JSON"}', content_type="application/json"
+            ) from None
 
         kwargs_view[self.arg_name] = self.model(**body)
 

--- a/aiohttp_pydantic/injectors.py
+++ b/aiohttp_pydantic/injectors.py
@@ -75,7 +75,9 @@ class BodyGetter(AbstractInjector):
         # to a dict. Prevent this by requiring the body to be a dict for object models.
         if self._expect_object and not isinstance(body, dict):
             raise HTTPBadRequest(
-                text='{"error": "Malformed JSON"}', content_type="application/json"
+                text='[{"in": "body", "loc": ["__root__"], "msg": "value is not a '
+                'valid dict", "type": "type_error.dict"}]',
+                content_type="application/json",
             ) from None
 
         kwargs_view[self.arg_name] = self.model.parse_obj(body)

--- a/aiohttp_pydantic/injectors.py
+++ b/aiohttp_pydantic/injectors.py
@@ -69,12 +69,8 @@ class BodyGetter(AbstractInjector):
             raise HTTPBadRequest(
                 text='{"error": "Malformed JSON"}', content_type="application/json"
             ) from None
-        if not type(body) == dict:
-            raise HTTPBadRequest(
-                text='{"error": "Malformed JSON"}', content_type="application/json"
-            ) from None
 
-        kwargs_view[self.arg_name] = self.model(**body)
+        kwargs_view[self.arg_name] = self.model.parse_obj(body)
 
 
 class QueryGetter(AbstractInjector):

--- a/tests/test_validation_body.py
+++ b/tests/test_validation_body.py
@@ -1,6 +1,5 @@
-from typing import Optional
+from typing import Iterator, List, Optional
 
-import pytest
 from aiohttp import web
 from pydantic import BaseModel
 
@@ -12,9 +11,19 @@ class ArticleModel(BaseModel):
     nb_page: Optional[int]
 
 
+class ArticleModels(BaseModel):
+    __root__: List[ArticleModel]
+
+    def __iter__(self) -> Iterator[ArticleModel]:
+        return iter(self.__root__)
+
+
 class ArticleView(PydanticView):
     async def post(self, article: ArticleModel):
         return web.json_response(article.dict())
+
+    async def put(self, articles: ArticleModels):
+        return web.json_response([article.dict() for article in articles])
 
 
 async def test_post_an_article_without_required_field_should_return_an_error_message(
@@ -57,18 +66,84 @@ async def test_post_an_article_with_wrong_type_field_should_return_an_error_mess
     ]
 
 
-@pytest.mark.parametrize("request_body", [["foo"], "bar", 42])
-async def test_post_json_with_non_object_top_structure_should_return_an_error_message(
-    aiohttp_client, loop, request_body
+async def test_post_an_array_json_is_supported(aiohttp_client, loop):
+    app = web.Application()
+    app.router.add_view("/article", ArticleView)
+
+    client = await aiohttp_client(app)
+    body = [{"name": "foo", "nb_page": 3}] * 2
+    resp = await client.put("/article", json=body)
+    assert resp.status == 200
+    assert resp.content_type == "application/json"
+    assert await resp.json() == body
+
+
+async def test_post_an_array_json_to_an_object_model_should_return_an_error(
+    aiohttp_client, loop
+):
+    """This test currently fails.
+
+    Pydantic apparently tries some weird magic here.
+    Making `nb_page` non-optional results in Pydantic rejecting the body, but it still
+    fails with a different error than the expected (at least, by me)
+    "Pet expected dict not list".
+
+    >>> from typing import Optional
+
+    >>> from pydantic import BaseModel
+
+
+    >>> class Pet(BaseModel):
+    ...    name: str
+    ...    age: Optional[int]
+
+
+    >>> Pet.parse_obj([{"name": "cat", "age": 2}]).__dict__
+    {'name': 'age', 'age': None}
+    >>> Pet.parse_obj([{"name": "cat", "foo": "bar"}]).__dict__
+    {'name': 'foo', 'age': None}
+    >>> Pet.parse_obj([{"name": "cat"}]).__dict__
+    Traceback (most recent call last):
+        ...
+    pydantic.error_wrappers.ValidationError: 1 validation error for Pet
+    __root__
+      Pet expected dict not list (type=type_error)
+    """
+    app = web.Application()
+    app.router.add_view("/article", ArticleView)
+
+    client = await aiohttp_client(app)
+    resp = await client.post("/article", json=[{"name": "foo", "nb_page": 3}])
+    assert resp.status == 400
+    assert resp.content_type == "application/json"
+    assert await resp.json() == [
+        {
+            "in": "body",
+            "loc": ["nb_page"],
+            "msg": "value is not a valid integer",
+            "type": "type_error.integer",
+        }
+    ]
+
+
+async def test_post_an_object_json_to_a_list_model_should_return_an_error(
+    aiohttp_client, loop
 ):
     app = web.Application()
     app.router.add_view("/article", ArticleView)
 
     client = await aiohttp_client(app)
-    resp = await client.post("/article", json=request_body)
+    resp = await client.put("/article", json={"name": "foo", "nb_page": 3})
     assert resp.status == 400
     assert resp.content_type == "application/json"
-    assert await resp.json() == {"error": "Malformed JSON"}
+    assert await resp.json() == [
+        {
+            "in": "body",
+            "loc": ["__root__"],
+            "msg": "value is not a valid list",
+            "type": "type_error.list",
+        }
+    ]
 
 
 async def test_post_a_valid_article_should_return_the_parsed_type(aiohttp_client, loop):
@@ -80,3 +155,9 @@ async def test_post_a_valid_article_should_return_the_parsed_type(aiohttp_client
     assert resp.status == 200
     assert resp.content_type == "application/json"
     assert await resp.json() == {"name": "foo", "nb_page": 3}
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()

--- a/tests/test_validation_body.py
+++ b/tests/test_validation_body.py
@@ -81,7 +81,7 @@ async def test_post_an_array_json_is_supported(aiohttp_client, loop):
 async def test_post_an_array_json_to_an_object_model_should_return_an_error(
     aiohttp_client, loop
 ):
-    """This test currently fails.
+    """This test currently fails, using Pydantic version 1.8.
 
     Pydantic apparently tries some weird magic here.
     Making `nb_page` non-optional results in Pydantic rejecting the body, but it still
@@ -116,14 +116,6 @@ async def test_post_an_array_json_to_an_object_model_should_return_an_error(
     resp = await client.post("/article", json=[{"name": "foo", "nb_page": 3}])
     assert resp.status == 400
     assert resp.content_type == "application/json"
-    assert await resp.json() == [
-        {
-            "in": "body",
-            "loc": ["nb_page"],
-            "msg": "value is not a valid integer",
-            "type": "type_error.integer",
-        }
-    ]
 
 
 async def test_post_an_object_json_to_a_list_model_should_return_an_error(

--- a/tests/test_validation_body.py
+++ b/tests/test_validation_body.py
@@ -88,7 +88,14 @@ async def test_post_an_array_json_to_an_object_model_should_return_an_error(
     resp = await client.post("/article", json=[{"name": "foo", "nb_page": 3}])
     assert resp.status == 400
     assert resp.content_type == "application/json"
-    assert await resp.json() == {"error": "Malformed JSON"}
+    assert await resp.json() == [
+        {
+            "in": "body",
+            "loc": ["__root__"],
+            "msg": "value is not a valid dict",
+            "type": "type_error.dict",
+        }
+    ]
 
 
 async def test_post_an_object_json_to_a_list_model_should_return_an_error(

--- a/tests/test_validation_body.py
+++ b/tests/test_validation_body.py
@@ -81,34 +81,6 @@ async def test_post_an_array_json_is_supported(aiohttp_client, loop):
 async def test_post_an_array_json_to_an_object_model_should_return_an_error(
     aiohttp_client, loop
 ):
-    """This test currently fails, using Pydantic version 1.8.
-
-    Pydantic apparently tries some weird magic here.
-    Making `nb_page` non-optional results in Pydantic rejecting the body, but it still
-    fails with a different error than the expected (at least, by me)
-    "Pet expected dict not list".
-
-    >>> from typing import Optional
-
-    >>> from pydantic import BaseModel
-
-
-    >>> class Pet(BaseModel):
-    ...    name: str
-    ...    age: Optional[int]
-
-
-    >>> Pet.parse_obj([{"name": "cat", "age": 2}]).__dict__
-    {'name': 'age', 'age': None}
-    >>> Pet.parse_obj([{"name": "cat", "foo": "bar"}]).__dict__
-    {'name': 'foo', 'age': None}
-    >>> Pet.parse_obj([{"name": "cat"}]).__dict__
-    Traceback (most recent call last):
-        ...
-    pydantic.error_wrappers.ValidationError: 1 validation error for Pet
-    __root__
-      Pet expected dict not list (type=type_error)
-    """
     app = web.Application()
     app.router.add_view("/article", ArticleView)
 
@@ -116,6 +88,7 @@ async def test_post_an_array_json_to_an_object_model_should_return_an_error(
     resp = await client.post("/article", json=[{"name": "foo", "nb_page": 3}])
     assert resp.status == 400
     assert resp.content_type == "application/json"
+    assert await resp.json() == {"error": "Malformed JSON"}
 
 
 async def test_post_an_object_json_to_a_list_model_should_return_an_error(
@@ -147,9 +120,3 @@ async def test_post_a_valid_article_should_return_the_parsed_type(aiohttp_client
     assert resp.status == 200
     assert resp.content_type == "application/json"
     assert await resp.json() == {"name": "foo", "nb_page": 3}
-
-
-if __name__ == "__main__":
-    import doctest
-
-    doctest.testmod()


### PR DESCRIPTION
When the `BodyGetter` class has to deal with a JSON that does not have an object as the top-level structure, it crashes. To replicate this behavior, simply send a POST request with request body `["foo"]` in the demo, or run the test scenario added in this PR without the changes to the `BodyGetter`.

Seeing as the request body is always parsed to a Pydantic model, and never to a nested structure like `List[<MyPydanticModel>]`, this change does not alter any behavior except for returning a 400 whenever a 500 would have been returned otherwise.

WDYT?

Awesome package, by the way!