### PR TITLE
Improve compatibility with web.View and support subclassing PydanticViews

### DIFF
--- a/aiohttp_pydantic/__init__.py
+++ b/aiohttp_pydantic/__init__.py
@@ -1,5 +1,5 @@
 from .view import PydanticView
 
-__version__ = "1.9.0"
+__version__ = "2.0.0"
 
 __all__ = ("PydanticView", "__version__")

--- a/aiohttp_pydantic/view.py
+++ b/aiohttp_pydantic/view.py
@@ -1,6 +1,6 @@
 from functools import update_wrapper
 from inspect import iscoroutinefunction
-from typing import Any, Callable, Generator, Iterable
+from typing import Any, Callable, Generator, Iterable, Set
 
 from aiohttp.abc import AbstractView
 from aiohttp.hdrs import METH_ALL
@@ -25,7 +25,7 @@ class PydanticView(AbstractView):
     """
 
     # Allowed HTTP methods; overridden when subclassed.
-    allowed_methods: set = {}
+    allowed_methods: Set[str] = {}
 
     async def _iter(self) -> StreamResponse:
         if (method_name := self.request.method) not in self.allowed_methods:

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -1,0 +1,58 @@
+from typing import Any
+
+from aiohttp_pydantic import PydanticView
+
+
+def count_wrappers(obj: Any) -> int:
+    """Count the number of times that an object is wrapped."""
+    i = 0
+    while i < 10:
+        try:
+            obj = obj.__wrapped__
+        except AttributeError:
+            return i
+        else:
+            i += 1
+    raise RuntimeError("Too many wrappers")
+
+
+class ViewParent(PydanticView):
+    async def put(self):
+        pass
+
+    async def delete(self):
+        pass
+
+
+class ViewParentNonPydantic:
+    async def post(self):
+        pass
+
+
+class ViewChild(ViewParent, ViewParentNonPydantic):
+    async def get(self):
+        pass
+
+    async def delete(self):
+        pass
+
+    async def not_allowed(self):
+        pass
+
+
+def test_allowed_methods_are_set_correctly():
+    assert ViewParent.allowed_methods == {"PUT", "DELETE"}
+    assert ViewChild.allowed_methods == {"GET", "POST", "PUT", "DELETE"}
+
+
+def test_allowed_methods_get_decorated_exactly_once():
+    assert count_wrappers(ViewParent.put) == 1
+    assert count_wrappers(ViewParent.delete) == 1
+    assert count_wrappers(ViewChild.get) == 1
+    assert count_wrappers(ViewChild.post) == 1
+    assert count_wrappers(ViewChild.put) == 1
+    assert count_wrappers(ViewChild.post) == 1
+    assert count_wrappers(ViewChild.put) == 1
+
+    assert count_wrappers(ViewChild.not_allowed) == 0
+    assert count_wrappers(ViewParentNonPydantic.post) == 0


### PR DESCRIPTION
The changes in this PR make `PydanticView` _structurally_ a subclass of the `aiohttp.web.View`. It should make it easier to use `PydanticView` in places where a regular `View` is expected.
The changes also allow one to inherit from a `PydanticView`.

### Rationale
I was working with `aiohttp_pydantic` in combination with some other tool, which are designed to work with a regular `View`. The tool assumed that for non-allowed methods, the handler attribute was missing. This is not the case for the current `PydanticView`, which sets the `raise_not_allowed` handler for such methods.

The tool would also subclass the `View`, which does not work for an `PydanticView`. Upon subclassing:
- all methods on the child view become "allowed methods", as the parent view gets a handler method even for the non-allwed methods;
- inherited, allowed methods are decorated again.

### Implementation
- Align the way unsupported methods are handles with `aiohttp.web.View`. This solves part of the inheritance problem, as no methods are attached for non-allowed methods.
- When subclassing, only decorate allowed methods that were not inherited from a `PydanticView` base class.

### Alternative solutions
For the inheritance problem, another solution could be to just raise a warning when a subclass of `PydanticView` is subclassed again. That does not solve the problem, but will let users know that this was not the intended usage.

Curious to hear your thoughts. I'm aware that this is a breaking change as it changes the public interface, but the added compatibility with regular the `View` should be useful.