### PR TITLE
Allow full schema customization

### DIFF
--- a/aiohttp_pydantic/oas/struct.py
+++ b/aiohttp_pydantic/oas/struct.py
@@ -310,6 +310,10 @@ class Components:
         self._spec = spec.setdefault("components", {})
 
     @property
+    def examples(self) -> dict:
+        return self._spec.setdefault("examples", {})
+
+    @property
     def schemas(self) -> dict:
         return self._spec.setdefault("schemas", {})
 

--- a/aiohttp_pydantic/oas/view.py
+++ b/aiohttp_pydantic/oas/view.py
@@ -132,6 +132,10 @@ def _add_http_method_to_oas(
             return_type
         )
 
+    customization = getattr(handler, '__modify_schema__', None)
+    if customization is not None:
+        customization(oas, oas_path, view, oas_operation)
+
 
 def generate_oas(
     apps: List[Application],

--- a/demo/customize.py
+++ b/demo/customize.py
@@ -1,0 +1,50 @@
+from typing import Union
+
+from aiohttp import web
+
+from aiohttp_pydantic import PydanticView
+from aiohttp_pydantic.oas.typing import r404
+
+from .model import Error, Pet
+
+
+DOG_DESCRIPTION = '''# Good boy
+
+This pet is a good boy and deserves lots of pets
+'''
+
+
+def add_markdown_response(func):
+    def modify(oas, oas_path, view, oas_operation):
+        oas.components.examples.setdefault('dog-example', {
+                'summary': 'A detailed listing for a dog',
+                'value': DOG_DESCRIPTION,
+            })
+
+        oas_operation.responses[200].content = {
+                'text/markdown': {
+                    'examples': {
+                        'dog': {
+                            '$ref': '#/components/examples/dog-example'
+                        }
+                    }
+                }
+            }
+
+    func.__modify_schema__ = modify
+    return func
+
+
+class PetDetailsView(PydanticView):
+    @add_markdown_response
+    async def get(self, id: int, /) -> r404[Error]:
+        """
+        Show a detailed listing describing the pet.
+
+        Status Codes:
+            200: The description for the pet was found
+            404: Pet not found
+        """
+        pet = self.request.app["model"].find_pet(id)
+        body = DOG_DESCRIPTION
+        return web.Response(content_type='text/markdown', body=body)

--- a/demo/main.py
+++ b/demo/main.py
@@ -4,6 +4,7 @@ from aiohttp_pydantic import oas
 
 from .model import Model
 from .view import PetCollectionView, PetItemView
+from .customize import PetDetailsView
 
 
 @middleware
@@ -20,3 +21,4 @@ oas.setup(app, version_spec="1.0.1", title_spec="My App")
 app["model"] = Model()
 app.router.add_view("/pets", PetCollectionView)
 app.router.add_view("/pets/{id}", PetItemView)
+app.router.add_view("/pets/{id}/details", PetDetailsView)


### PR DESCRIPTION
Adds a full callback hook to customize schema _after_ the type annotations have been processed, not unlike `pydantics` own [`__modify_schema__`](https://pydantic-docs.helpmanual.io/usage/schema/#modifying-schema-in-custom-fields) customization point. The goal here is to provide a suitable _fallback_ for arbitrary modifications to the OpenAPI specification, in case the provided attribute processing is not yet ready for the details. The alternative, implementing the full available OpenAPI fields, is unlikely to be feasible and not readily translate to annotations.