### PR TITLE
Fix/relative static path

### DIFF
--- a/aiohttp_pydantic/oas/index.j2
+++ b/aiohttp_pydantic/oas/index.j2
@@ -4,9 +4,9 @@
   <head>
     <meta charset="UTF-8">
     <title>{{ title | default('Swagger UI') }}</title>
-    <link rel="stylesheet" type="text/css" href="{{ static_url | trim('/') }}/swagger-ui.css" >
-    <link rel="icon" type="image/png" href="{{ static_url | trim('/') }}/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="{{ static_url | trim('/') }}/favicon-16x16.png" sizes="16x16" />
+    <link rel="stylesheet" type="text/css" href="{{ static_url }}/swagger-ui.css" >
+    <link rel="icon" type="image/png" href="{{ static_url }}/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="{{ static_url }}/favicon-16x16.png" sizes="16x16" />
     <style>
       html
       {
@@ -33,8 +33,8 @@
   <body>
     <div id="swagger-ui"></div>
 
-    <script src="{{ static_url | trim('/') }}/swagger-ui-bundle.js"> </script>
-    <script src="{{ static_url | trim('/') }}/swagger-ui-standalone-preset.js"> </script>
+    <script src="{{ static_url }}/swagger-ui-bundle.js"> </script>
+    <script src="{{ static_url }}/swagger-ui-standalone-preset.js"> </script>
     <script>
     window.onload = function() {
       // Begin Swagger UI call region

--- a/aiohttp_pydantic/oas/view.py
+++ b/aiohttp_pydantic/oas/view.py
@@ -181,13 +181,12 @@ async def oas_ui(request):
     View to serve the swagger-ui to read open api specification of application.
     """
     template = request.app["index template"]
-    root = request.app.router['index'].canonical
 
     return Response(
         text=template.render(
             {
-                "openapi_spec_url": f"{root}/spec",
-                "static_url": f"{root}/static",
+                "openapi_spec_url": request.app.router['spec'].canonical,
+                "static_url": request.app.router['static'].canonical,
             }
         ),
         content_type="text/html",

--- a/aiohttp_pydantic/oas/view.py
+++ b/aiohttp_pydantic/oas/view.py
@@ -1,18 +1,17 @@
 import typing
 from inspect import getdoc
 from itertools import count
-from typing import List, Type, Optional, get_type_hints
+from typing import List, Optional, Type, get_type_hints
 
 from aiohttp.web import Response, json_response
 from aiohttp.web_app import Application
 from pydantic import BaseModel
 
-from aiohttp_pydantic.oas.struct import OpenApiSpec3, OperationObject, PathItem
-from . import docstring_parser
-
 from ..injectors import _parse_func_signature
 from ..utils import is_pydantic_base_model
 from ..view import PydanticView, is_pydantic_view
+from . import docstring_parser
+from .struct import OpenApiSpec3, OperationObject, PathItem
 from .typing import is_status_code_type
 
 
@@ -182,16 +181,13 @@ async def oas_ui(request):
     View to serve the swagger-ui to read open api specification of application.
     """
     template = request.app["index template"]
-
-    static_url = request.app.router["static"].url_for(filename="")
-    spec_url = request.app.router["spec"].url_for()
-    host = request.url.origin()
+    root = request.app.router['index'].canonical
 
     return Response(
         text=template.render(
             {
-                "openapi_spec_url": host.with_path(str(spec_url)),
-                "static_url": host.with_path(str(static_url)),
+                "openapi_spec_url": f"{root}/spec",
+                "static_url": f"{root}/static",
             }
         ),
         content_type="text/html",


### PR DESCRIPTION
## Problem

The OAS page template is initialized with fully qualified URLs that include protocol (http/https).
This assumption is invalid when the app is placed behind a reverse proxy that handles SSL termination. The app requests static files over http while the browser has requested a https page.

## Implementation

The `static_url` and `openapi_spec_url` variables used in template initialization are changed to be paths relative to the root.

Previously: `http://host.com:8080/parent_app_prefix/oas/static`
Now: `/parent_app_prefix/oas/static`

To retain the initial `/` in the path, the static_url trim is removed from index.j2.