### PR TITLE
Empty HTTP body is not Malformed JSON

### DIFF
--- a/aiohttp_pydantic/injectors.py
+++ b/aiohttp_pydantic/injectors.py
@@ -71,12 +71,15 @@ class BodyGetter(AbstractInjector):
         self._expect_object = self.model.schema()["type"] == "object"
 
     async def inject(self, request: BaseRequest, args_view: list, kwargs_view: dict):
-        try:
-            body = await request.json()
-        except JSONDecodeError:
-            raise HTTPBadRequest(
-                text='{"error": "Malformed JSON"}', content_type="application/json"
-            ) from None
+        if not request.has_body or request.content_length == 0:
+            body = {}
+        else:
+            try:
+                body = await request.json()
+            except JSONDecodeError:
+                raise HTTPBadRequest(
+                    text='{"error": "Malformed JSON"}', content_type="application/json"
+                ) from None
 
         # Pydantic tries to cast certain structures, such as a list of 2-tuples,
         # to a dict. Prevent this by requiring the body to be a dict for object models.


### PR DESCRIPTION
Consider the following example:

``` python
from __future__ import annotations
from typing import Optional
from aiohttp import web
from pydantic import BaseModel
from aiohttp_pydantic import PydanticView

class ArticleModel(BaseModel):
    foo: Optional[str] = None

class ArticleView(PydanticView):
    async def post(self, article: ArticleModel):
        return web.Response(status=200)

app = web.Application()
app.router.add_view("/test", ArticleView)
web.run_app(app)
```

A request with an empty body should meet the constraints of `ArticleModel` because the sole field `foo` is optional. An empty body can be `{}`, content-length 0, or an empty body payload. As aiohttp-pydantic treats request bodies as JSON, all but the former throw a Malformed JSON error.

``` bash
$ curl -X POST http://127.0.0.1:8080/test --data '{}'  # ok
$ curl -X POST http://127.0.0.1:8080/test
{"error": "Malformed JSON"}
$ curl -X POST http://127.0.0.1:8080/test --data ''
{"error": "Malformed JSON"}
```
Sending an empty body from a client is not uncommon. See [this thread](https://lists.w3.org/Archives/Public/ietf-http-wg/2010JulSep/0272.html) on the IETF HTTP working group mailing list.