### PR TITLE
Tommmlij/fix custom types

### DIFF
--- a/aiohttp_pydantic/injectors.py
+++ b/aiohttp_pydantic/injectors.py
@@ -235,7 +235,7 @@ def _parse_func_signature(
     header_args = {}
     defaults = {}
 
-    annotations = get_type_hints(func)
+    annotations = get_type_hints(func, include_extras=True)
     for param_name, param_spec in signature(func).parameters.items():
 
         if param_name == "self":

--- a/aiohttp_pydantic/injectors.py
+++ b/aiohttp_pydantic/injectors.py
@@ -211,7 +211,7 @@ def _get_group_signature(cls) -> Tuple[dict, dict]:
                 defaults[attr_name] = default
 
         # Use get_type_hints to have postponed annotations.
-        for attr_name, type_ in get_type_hints(base).items():
+        for attr_name, type_ in get_type_hints(base, include_extras=True).items():
             sig[attr_name] = type_
 
     return sig, defaults

--- a/tests/test_validation_header.py
+++ b/tests/test_validation_header.py
@@ -98,8 +98,8 @@ async def test_get_article_with_wrong_header_type_should_return_an_error_message
             "input": "foo",
             "ctx": {"error": "input is too short"},
             "loc": ["signature_expired"],
-            "msg": "Input should be a valid datetime, input is too short",
-            "type": "datetime_parsing",
+            "msg": "Input should be a valid datetime or date, input is too short",
+            "type": "datetime_from_date_parsing",
         }
     ]
 


### PR DESCRIPTION
After some tests, I found out that adding the `include_extras` parameter when inferring the types, would lead to annotations being carried over to request validation. This leads to this working:

```python
from aiohttp.web import json_response, Application, run_app
from pydantic import Base64UrlStr, SerializeAsAny
from aiohttp_pydantic import PydanticView


class MyView(PydanticView):

    async def get(self, search: SerializeAsAny[Base64UrlStr], /):
        return json_response({"search": search})


if __name__ == '__main__':
    app = Application()
    app.router.add_view('/{search}', MyView)
    run_app(app)
```

```shell
curl localhost:8080/Zm9v
# {"search": "foo"}

curl localhost:8080/foo
# [{"type": "base64_decode", "loc": ["search"], "msg": "Base64 decoding error: 'Incorrect padding'", "input": "foo", "ctx": {"error": "Incorrect padding"}, "in": "path"}]
```

So base64 decoding implicitly via the type. That is awesome. But I am not 100% sure about problems with that. Tests are running through.

P.S.: Thx for the good work, the project is really enhancing the work with my aiohttp-servers.
