### PR TITLE
App key as web.AppKey

### DIFF
--- a/aiohttp_pydantic/oas/__init__.py
+++ b/aiohttp_pydantic/oas/__init__.py
@@ -6,6 +6,8 @@ from aiohttp import web
 from swagger_ui_bundle import swagger_ui_path
 
 from .view import get_oas, oas_ui
+from .definition import (
+    key_apps_to_expose, key_index_template, key_version_spec, key_title_spec)
 
 
 def setup(
@@ -18,12 +20,12 @@ def setup(
 ):
     if enable:
         oas_app = web.Application()
-        oas_app["apps to expose"] = tuple(apps_to_expose) or (app,)
-        oas_app["index template"] = jinja2.Template(
+        oas_app[key_apps_to_expose] = tuple(apps_to_expose) or (app,)
+        oas_app[key_index_template] = jinja2.Template(
             resources.read_text("aiohttp_pydantic.oas", "index.j2")
         )
-        oas_app["version_spec"] = version_spec
-        oas_app["title_spec"] = title_spec
+        oas_app[key_version_spec] = version_spec
+        oas_app[key_title_spec] = title_spec
 
         oas_app.router.add_get("/spec", get_oas, name="spec")
         oas_app.router.add_static("/static", swagger_ui_path, name="static")

--- a/aiohttp_pydantic/oas/definition.py
+++ b/aiohttp_pydantic/oas/definition.py
@@ -1,0 +1,17 @@
+"""
+Definitions
+"""
+
+from aiohttp import web
+
+key_apps_to_expose = web.AppKey("apps to expose")
+key_index_template = web.AppKey("index template")
+key_version_spec = web.AppKey("version spec")
+key_title_spec = web.AppKey("title spec")
+
+__all__ = [
+    key_apps_to_expose,
+    key_index_template,
+    key_version_spec,
+    key_title_spec,
+]

--- a/aiohttp_pydantic/oas/view.py
+++ b/aiohttp_pydantic/oas/view.py
@@ -13,6 +13,8 @@ from ..view import PydanticView, is_pydantic_view
 from . import docstring_parser
 from .struct import OpenApiSpec3, OperationObject, PathItem
 from .typing import is_status_code_type
+from .definition import (
+    key_apps_to_expose, key_index_template, key_version_spec, key_title_spec)
 
 
 class _OASResponseBuilder:
@@ -171,9 +173,9 @@ async def get_oas(request):
     """
     View to generate the Open Api Specification from PydanticView in application.
     """
-    apps = request.app["apps to expose"]
-    version_spec = request.app["version_spec"]
-    title_spec = request.app["title_spec"]
+    apps = request.app[key_apps_to_expose]
+    version_spec = request.app[key_version_spec]
+    title_spec = request.app[key_title_spec]
     return json_response(generate_oas(apps, version_spec, title_spec))
 
 
@@ -181,7 +183,7 @@ async def oas_ui(request):
     """
     View to serve the swagger-ui to read open api specification of application.
     """
-    template = request.app["index template"]
+    template = request.app[key_index_template]
 
     return Response(
         text=template.render(

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.5
+aiohttp==3.9.5
 aiosignal==1.3.1
 annotated-types==0.5.0
 async-timeout==4.0.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ include_package_data = True
 packages = find:
 python_requires = >=3.8
 install_requires =
-    aiohttp
+    aiohttp>=3.9
     pydantic>=2.0,<3.0
     swagger-ui-bundle
 


### PR DESCRIPTION
To work with keys that are inside the App, starting from version 3.9, it is recommended to use the object web.AppKey

Up minimal version of aiohttp - 3.9.0

Docs: https://docs.aiohttp.org/en/stable/_modules/aiohttp/web_app.html