### PR TITLE
Enable security features

### DIFF
--- a/aiohttp_pydantic/oas/__init__.py
+++ b/aiohttp_pydantic/oas/__init__.py
@@ -7,7 +7,7 @@ from swagger_ui_bundle import swagger_ui_path
 
 from .view import get_oas, oas_ui
 from .definition import (
-    key_apps_to_expose, key_index_template, key_version_spec, key_title_spec)
+    key_apps_to_expose, key_index_template, key_version_spec, key_title_spec, key_security)
 
 
 def setup(
@@ -17,6 +17,7 @@ def setup(
     enable: bool = True,
     version_spec: Optional[str] = None,
     title_spec: Optional[str] = None,
+    security: Optional[dict] = None,
 ):
     if enable:
         oas_app = web.Application()
@@ -26,6 +27,7 @@ def setup(
         )
         oas_app[key_version_spec] = version_spec
         oas_app[key_title_spec] = title_spec
+        oas_app[key_security] = security
 
         oas_app.router.add_get("/spec", get_oas, name="spec")
         oas_app.router.add_static("/static", swagger_ui_path, name="static")

--- a/aiohttp_pydantic/oas/definition.py
+++ b/aiohttp_pydantic/oas/definition.py
@@ -23,11 +23,12 @@ key_apps_to_expose = web.AppKey("apps to expose", Iterable[web.Application])
 key_index_template = web.AppKey("index template", str)
 key_version_spec = web.AppKey("version spec", str)
 key_title_spec = web.AppKey("title spec", str)
-
+key_security = web.AppKey("security", dict)
 
 __all__ = [
     key_apps_to_expose,
     key_index_template,
     key_version_spec,
     key_title_spec,
+    key_security,
 ]

--- a/aiohttp_pydantic/oas/docstring_parser.py
+++ b/aiohttp_pydantic/oas/docstring_parser.py
@@ -4,7 +4,7 @@ Utility to extract extra OAS description from docstring.
 
 import re
 import textwrap
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 
 class LinesIterator:
@@ -120,7 +120,7 @@ def tags(docstring: str) -> List[str]:
     return []
 
 
-def security(docstring: str) -> List[dict] | None:
+def security(docstring: str) -> Optional[List[dict]]:
     """
     Extract the "Security:" block of the docstring.
     """

--- a/aiohttp_pydantic/oas/docstring_parser.py
+++ b/aiohttp_pydantic/oas/docstring_parser.py
@@ -120,6 +120,21 @@ def tags(docstring: str) -> List[str]:
     return []
 
 
+def security(docstring: str) -> List[dict] | None:
+    """
+    Extract the "Security:" block of the docstring.
+    """
+    iterator = LinesIterator(docstring)
+    for line in iterator:
+        if re.fullmatch("security\\s*:.*", line, re.IGNORECASE):
+            iterator.rewind()
+            lines = " ".join(_i_extract_block(iterator))
+            security_items = [" ".join(e.split()) for e in re.split("[,;]", lines.split(":")[1])]
+            return [{item: [] for item in security_items}]
+
+    return None
+
+
 def deprecated(docstring: str) -> bool:
     """
     Extract the "Deprecated:" block of the docstring.
@@ -138,7 +153,7 @@ def operation(docstring: str) -> str:
     lines = LinesIterator(docstring)
     ret = []
     for line in lines:
-        if re.fullmatch("status\\s+codes?\\s*:|tags\\s*:.*", line, re.IGNORECASE):
+        if re.fullmatch("status\\s+codes?\\s*:|tags\\s*:.*|security\\s*:.*", line, re.IGNORECASE):
             lines.rewind()
             for _ in _i_extract_block(lines):
                 pass

--- a/aiohttp_pydantic/oas/struct.py
+++ b/aiohttp_pydantic/oas/struct.py
@@ -177,6 +177,15 @@ class OperationObject:
         self._spec["summary"] = summary
 
     @property
+    def security(self) -> List[dict]:
+        return self._spec.get("security", [])
+
+    @security.setter
+    def security(self, security: List[dict] | None):
+        if security is not None:
+            self._spec["security"] = security
+
+    @property
     def description(self) -> str:
         return self._spec["description"]
 

--- a/aiohttp_pydantic/oas/struct.py
+++ b/aiohttp_pydantic/oas/struct.py
@@ -331,6 +331,10 @@ class Components:
     def schemas(self) -> dict:
         return self._spec.setdefault("schemas", {})
 
+    @property
+    def security_schemes(self) -> dict:
+        return self._spec.setdefault("securitySchemes", {})
+
 
 class OpenApiSpec3:
     def __init__(self):

--- a/aiohttp_pydantic/oas/view.py
+++ b/aiohttp_pydantic/oas/view.py
@@ -96,6 +96,7 @@ def _add_http_method_to_oas(
     if description:
         oas_operation.description = docstring_parser.operation(description)
         oas_operation.tags = docstring_parser.tags(description)
+        oas_operation.security = docstring_parser.security(description)
         oas_operation.deprecated = docstring_parser.deprecated(description)
         status_code_descriptions = docstring_parser.status_code(description)
     else:

--- a/aiohttp_pydantic/oas/view.py
+++ b/aiohttp_pydantic/oas/view.py
@@ -18,6 +18,7 @@ from .definition import (
     key_index_template,
     key_title_spec,
     key_version_spec,
+    key_security,
 )
 from .struct import OpenApiSpec3, OperationObject, PathItem
 from .typing import is_status_code_type
@@ -148,6 +149,7 @@ def generate_oas(
     apps: List[Application],
     version_spec: Optional[str] = None,
     title_spec: Optional[str] = None,
+    security: Optional[dict] = None,
 ) -> dict:
     """
     Generate and return Open Api Specification from PydanticView in application.
@@ -175,6 +177,9 @@ def generate_oas(
                 else:
                     _add_http_method_to_oas(oas, path, resource_route.method, view)
 
+    if security:
+        oas.components.security_schemes.update(security)
+
     return oas.spec
 
 
@@ -195,7 +200,8 @@ async def get_oas(request):
     apps = _app_key_or_string(request.app, key_apps_to_expose, "apps to expose")
     version_spec = _app_key_or_string(request.app, key_version_spec, "version spec")
     title_spec = _app_key_or_string(request.app, key_title_spec, "title spec")
-    return json_response(generate_oas(apps, version_spec, title_spec))
+    security = _app_key_or_string(request.app, key_security, "security")
+    return json_response(generate_oas(apps, version_spec, title_spec, security))
 
 
 async def oas_ui(request):

--- a/demo/__main__.py
+++ b/demo/__main__.py
@@ -1,5 +1,5 @@
 from aiohttp import web
 
-from .main import app
+from main import app
 
 web.run_app(app)

--- a/demo/main.py
+++ b/demo/main.py
@@ -2,8 +2,8 @@ from aiohttp.web import Application, json_response, middleware
 
 from aiohttp_pydantic import oas
 
-from .model import Model
-from .view import PetCollectionView, PetItemView
+from model import Model
+from view import PetCollectionView, PetItemView
 
 
 @middleware
@@ -15,7 +15,7 @@ async def pet_not_found_to_404(request, handler):
 
 
 app = Application(middlewares=[pet_not_found_to_404])
-oas.setup(app, version_spec="1.0.1", title_spec="My App")
+oas.setup(app, version_spec="1.0.1", title_spec="My App", security={"APIKeyHeader": {"type": "apiKey", "in": "header", "name": "Authorization"}})
 
 app["model"] = Model()
 app.router.add_view("/pets", PetCollectionView)

--- a/demo/view.py
+++ b/demo/view.py
@@ -5,7 +5,7 @@ from aiohttp import web
 from aiohttp_pydantic import PydanticView
 from aiohttp_pydantic.oas.typing import r200, r201, r204, r404
 
-from .model import Error, Pet
+from model import Error, Pet
 
 
 class PetCollectionView(PydanticView):
@@ -24,6 +24,8 @@ class PetCollectionView(PydanticView):
     async def post(self, pet: Pet) -> r201[Pet]:
         """
         Add a new pet to the store
+
+        Security: APIKeyHeader
 
         Status Codes:
             201: Successful operation

--- a/tests/test_oas/test_view.py
+++ b/tests/test_oas/test_view.py
@@ -278,7 +278,7 @@ async def test_pets_id_route_should_have_get_method(generated_oas):
                 "name": "day",
                 "required": False,
                 "schema": {
-                    "anyOf": [{"type": "integer"}, {"const": "now"}],
+                    "anyOf": [{"type": "integer"}, {"const": "now", "enum": ["now"], "type": "string"}],
                     "default": "now",
                     "title": "day",
                 },

--- a/tests/test_oas/test_view.py
+++ b/tests/test_oas/test_view.py
@@ -33,11 +33,12 @@ class Pet(BaseModel):
 
 class PetCollectionView(PydanticView):
     async def get(
-        self, format: str, name: Optional[str] = None, *, promo: Optional[UUID] = None
+            self, format: str, name: Optional[str] = None, *, promo: Optional[UUID] = None
     ) -> r200[List[Pet]]:
         """
         Get a list of pets
 
+        Security: APIKeyHeader
         Tags: pet
         Status Codes:
           200: Successful operation
@@ -51,11 +52,11 @@ class PetCollectionView(PydanticView):
 
 class PetItemView(PydanticView):
     async def get(
-        self,
-        id: int,
-        /,
-        size: Union[int, Literal["x", "l", "s"]],
-        day: Union[int, Literal["now"]] = "now",
+            self,
+            id: int,
+            /,
+            size: Union[int, Literal["x", "l", "s"]],
+            day: Union[int, Literal["now"]] = "now",
     ) -> Union[r200[Pet], r404]:
         return web.json_response()
 
@@ -135,6 +136,11 @@ async def test_pets_route_should_have_get_method(generated_oas):
     assert generated_oas["paths"]["/pets"]["get"] == {
         "description": "Get a list of pets",
         "tags": ["pet"],
+        'security': [
+            {
+                'APIKeyHeader': [],
+            },
+        ],
         "parameters": [
             {
                 "in": "query",
@@ -152,7 +158,8 @@ async def test_pets_route_should_have_get_method(generated_oas):
                 "in": "header",
                 "name": "promo",
                 "required": False,
-                "schema": {"anyOf": [{"format": "uuid", "type": "string"}, {"type": "null"}], "title": "promo", "default": None},
+                "schema": {"anyOf": [{"format": "uuid", "type": "string"}, {"type": "null"}], "title": "promo",
+                           "default": None},
             },
         ],
         "responses": {

--- a/tests/test_oas/test_view.py
+++ b/tests/test_oas/test_view.py
@@ -285,7 +285,7 @@ async def test_pets_id_route_should_have_get_method(generated_oas):
                 "name": "day",
                 "required": False,
                 "schema": {
-                    "anyOf": [{"type": "integer"}, {"const": "now", "enum": ["now"], "type": "string"}],
+                    "anyOf": [{"type": "integer"}, {"const": "now"}],
                     "default": "now",
                     "title": "day",
                 },

--- a/tests/test_validation_header.py
+++ b/tests/test_validation_header.py
@@ -98,8 +98,8 @@ async def test_get_article_with_wrong_header_type_should_return_an_error_message
             "input": "foo",
             "ctx": {"error": "input is too short"},
             "loc": ["signature_expired"],
-            "msg": "Input should be a valid datetime, input is too short",
-            "type": "datetime_parsing",
+            "msg": "Input should be a valid datetime or date, input is too short",
+            "type": "datetime_from_date_parsing",
         }
     ]
 

--- a/tests/test_validation_header.py
+++ b/tests/test_validation_header.py
@@ -98,8 +98,8 @@ async def test_get_article_with_wrong_header_type_should_return_an_error_message
             "input": "foo",
             "ctx": {"error": "input is too short"},
             "loc": ["signature_expired"],
-            "msg": "Input should be a valid datetime or date, input is too short",
-            "type": "datetime_from_date_parsing",
+            "msg": "Input should be a valid datetime, input is too short",
+            "type": "datetime_parsing",
         }
     ]
 


### PR DESCRIPTION
I missed authorization from swagger web. We used to create endpoints that require Authorization header and it was not correctly attached to the request. I decided to add securitySchemes directly to the spec which allows to authorize for all requests and mark specific endpoints as ones that require authorization.

It looks as follows on the UI:
![obraz](https://github.com/Maillol/aiohttp-pydantic/assets/54535478/3f255dac-35b3-44b8-a091-7f8855bfc798)
