### PR TITLE
Fixed a Pydantic ValueError caused when a user applies custom validation in Pydantic Model

### DIFF
--- a/aiohttp_pydantic/decorator.py
+++ b/aiohttp_pydantic/decorator.py
@@ -22,7 +22,8 @@ async def json_response_error(
     errors = exception.errors(include_url=False)
     for error in errors:
         error["in"] = context
-
+        if "ctx" in error:
+            error["ctx"]["error"] = str(error["ctx"]["error"])
     return json_response(data=errors, status=400)
 
 
@@ -140,7 +141,6 @@ def _inject_params(
     ],
     Handler,
 ]:
-
     if decorate_method and inject_request:
         raise ValueError("Cannot set decorate_method and inject_request both")
 


### PR DESCRIPTION
I have fixed Pydantic ValueError in `json_response_error` method, Here is the fixed code.
```
async def json_response_error(
    exception: ValidationError, context: CONTEXT
) -> StreamResponse:
    errors = exception.errors(include_url=False)
    for error in errors:
        error["in"] = context
        if "ctx" in error:
            error["ctx"]["error"] = str(error["ctx"]["error"]) #Added, wrapped with str class.
    return json_response(data=errors, status=400)
```