### PR TITLE
Fix OAS generation - description

### DIFF
--- a/aiohttp_pydantic/oas/view.py
+++ b/aiohttp_pydantic/oas/view.py
@@ -186,6 +186,9 @@ def _add_http_method_to_oas(
             )
             if def_sub_schemas := attr_schema.pop("$defs", None):
                 oas.components.schemas.update(def_sub_schemas)
+            # update description
+            if "description" in attr_schema:
+                oas_operation.parameters[i].description = attr_schema.pop("description")
             oas_operation.parameters[i].schema = attr_schema
 
     return_type = get_type_hints(handler).get("return")

--- a/tests/test_oas/bench/decorated_handler.py
+++ b/tests/test_oas/bench/decorated_handler.py
@@ -5,15 +5,21 @@ from typing import List, Optional, Union, Literal
 from uuid import UUID
 
 from aiohttp import web
+from pydantic import Field
 from aiohttp_pydantic.oas.typing import r200, r201, r204, r404
 from aiohttp_pydantic import oas
 from aiohttp_pydantic.decorator import inject_params
+
 from .model import Pet
 
 
 @inject_params
 async def list_pet(
-    format: str, name: Optional[str] = None, *, promo: Optional[UUID] = None
+    format: str,
+    name: Optional[str] = None,
+    *,
+    promo: Optional[UUID] = Field(
+        None, description="description for promo")
 ) -> r200[List[Pet]]:
     """
     Get a list of pets

--- a/tests/test_oas/bench/decorated_handler_with_request.py
+++ b/tests/test_oas/bench/decorated_handler_with_request.py
@@ -5,15 +5,22 @@ from typing import List, Optional, Union, Literal
 from uuid import UUID
 
 from aiohttp import web
+from pydantic import Field
 from aiohttp_pydantic.oas.typing import r200, r201, r204, r404
 from aiohttp_pydantic import oas
 from aiohttp_pydantic.decorator import inject_params
+
 from .model import Pet
 
 
 @inject_params.and_request
 async def list_pet(
-    request, format: str, name: Optional[str] = None, *, promo: Optional[UUID] = None
+    request,
+    format: str,
+    name: Optional[str] = None,
+    *,
+    promo: Optional[UUID] = Field(
+        None, description="description for promo")
 ) -> r200[List[Pet]]:
     """
     Get a list of pets

--- a/tests/test_oas/bench/pydantic_view.py
+++ b/tests/test_oas/bench/pydantic_view.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Union, Literal
 from uuid import UUID
 
 from aiohttp import web
+from pydantic import Field
 
 from aiohttp_pydantic import PydanticView
 from aiohttp_pydantic.oas.typing import r200, r201, r204, r404
@@ -15,7 +16,12 @@ from .model import Pet
 
 class PetCollectionView(PydanticView):
     async def get(
-        self, format: str, name: Optional[str] = None, *, promo: Optional[UUID] = None
+        self,
+        format: str,
+        name: Optional[str] = None,
+        *,
+        promo: Optional[UUID] = Field(
+            None, description="description for promo")
     ) -> r200[List[Pet]]:
         """
         Get a list of pets
@@ -27,7 +33,10 @@ class PetCollectionView(PydanticView):
         """
         return web.json_response()
 
-    async def post(self, pet: Pet) -> r201[Pet]:
+    async def post(
+        self,
+        pet: Pet
+    ) -> r201[Pet]:
         """Create a Pet"""
         return web.json_response()
 

--- a/tests/test_oas/bench/view.py
+++ b/tests/test_oas/bench/view.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Union, Literal
 from uuid import UUID
 
 from aiohttp import web
+from pydantic import Field
 
 from aiohttp_pydantic.oas.typing import r200, r201, r204, r404
 from aiohttp_pydantic import oas
@@ -16,7 +17,12 @@ class PetCollectionView(web.View):
 
     @inject_params.in_method
     async def get(
-        self, format: str, name: Optional[str] = None, *, promo: Optional[UUID] = None
+        self,
+        format: str,
+        name: Optional[str] = None,
+        *,
+        promo: Optional[UUID] = Field(
+            None, description="description for promo")
     ) -> r200[List[Pet]]:
         """
         Get a list of pets

--- a/tests/test_oas/test_view.py
+++ b/tests/test_oas/test_view.py
@@ -124,8 +124,8 @@ async def test_pets_route_should_have_get_method(generate_oas, aiohttp_client, e
                     "anyOf": [{"format": "uuid", "type": "string"}, {"type": "null"}],
                     "title": "promo",
                     "default": None,
-                    "description": "description for promo",
                 },
+                "description": "description for promo",
             },
         ],
         "responses": {

--- a/tests/test_oas/test_view.py
+++ b/tests/test_oas/test_view.py
@@ -124,6 +124,7 @@ async def test_pets_route_should_have_get_method(generate_oas, aiohttp_client, e
                     "anyOf": [{"format": "uuid", "type": "string"}, {"type": "null"}],
                     "title": "promo",
                     "default": None,
+                    "description": "description for promo",
                 },
             },
         ],


### PR DESCRIPTION
Example

```
class PetCollectionView(PydanticView):
    async def get(
        self,
        format: str,
        name: Optional[str] = None,
        *,
        promo: Optional[UUID] = Field(
            None, description="description for promo")
    ) -> r200[List[Pet]]:
        """
        Get a list of pets
        """
        return web.json_response()
```

for the field 'promo' we got this oas:
```
info:
  title: API Server
  version: 1.0.0
openapi: 3.0.0
paths:
  /test:
    get:
      description: test
      parameters:
        - in: query
          name: format
          required: true
          schema:
            title: format
            type: string

        - in: query
          name: name
          required: false
          schema:
            anyOf:
              - type: string
              - type: null
            default: null
            title: name

        - in: header
          name: promo
          required: false
          schema:
            anyOf:
              - format: uuid
                type: string
              - type: null
            title: promo
            default: null
            description: description for promo
```

The description of field 'promo' stand not correct place. It shoud place as:
```
       - in: header
          name: promo
          required: false
          schema:
            anyOf:
              - format: uuid
                type: string
              - type: null
            title: promo
            default: null
          description: description for promo
```
