### PR TITLE
Fix, the field is set required if FieldInfo is required

### DIFF
--- a/aiohttp_pydantic/oas/view.py
+++ b/aiohttp_pydantic/oas/view.py
@@ -8,6 +8,7 @@ from aiohttp import hdrs
 from aiohttp.web import Response, json_response, View
 from aiohttp.web_app import Application
 from pydantic import RootModel
+from pydantic.fields import FieldInfo
 
 from ..injectors import _parse_func_signature
 from ..uploaded_file import UploadedFile
@@ -175,7 +176,13 @@ def _add_http_method_to_oas(
             oas_operation.parameters[i].name = name
 
             attrs = {"__annotations__": {"root": type_}}
-            if name in defaults:
+            if (
+                name in defaults and
+                not (
+                    isinstance(defaults[name], FieldInfo) and
+                    defaults[name].is_required()
+                )
+            ):
                 attrs["root"] = defaults[name]
                 oas_operation.parameters[i].required = False
             else:

--- a/tests/test_oas/bench/decorated_handler.py
+++ b/tests/test_oas/bench/decorated_handler.py
@@ -15,7 +15,7 @@ from .model import Pet
 
 @inject_params
 async def list_pet(
-    format: str,
+    format: str = Field(...),
     name: Optional[str] = None,
     *,
     promo: Optional[UUID] = Field(

--- a/tests/test_oas/bench/decorated_handler_with_request.py
+++ b/tests/test_oas/bench/decorated_handler_with_request.py
@@ -16,7 +16,7 @@ from .model import Pet
 @inject_params.and_request
 async def list_pet(
     request,
-    format: str,
+    format: str = Field(...),
     name: Optional[str] = None,
     *,
     promo: Optional[UUID] = Field(

--- a/tests/test_oas/bench/pydantic_view.py
+++ b/tests/test_oas/bench/pydantic_view.py
@@ -17,7 +17,7 @@ from .model import Pet
 class PetCollectionView(PydanticView):
     async def get(
         self,
-        format: str,
+        format: str = Field(...),
         name: Optional[str] = None,
         *,
         promo: Optional[UUID] = Field(

--- a/tests/test_oas/bench/view.py
+++ b/tests/test_oas/bench/view.py
@@ -18,7 +18,7 @@ class PetCollectionView(web.View):
     @inject_params.in_method
     async def get(
         self,
-        format: str,
+        format: str = Field(...),
         name: Optional[str] = None,
         *,
         promo: Optional[UUID] = Field(


### PR DESCRIPTION
Fix,
if in model the field set `Field(...)`, this field should be required, but that was incorrect

Example:
```
class PetCollectionView(PydanticView):
    async def get(
        self,
        format: str = Field(...),
    ) -> r200[List[Pet]]:
        pass
```