### PR TITLE
Fix add description if field is required

### DIFF
--- a/aiohttp_pydantic/oas/view.py
+++ b/aiohttp_pydantic/oas/view.py
@@ -178,17 +178,14 @@ def _add_http_method_to_oas(
             oas_operation.parameters[i].name = name
 
             attrs = {"__annotations__": {"root": type_}}
-            if (
-                name in defaults and
-                not (
+            oas_operation.parameters[i].required = True
+            if name in defaults:
+                attrs["root"] = defaults[name]
+                if not (
                     isinstance(defaults[name], FieldInfo) and
                     defaults[name].is_required()
-                )
-            ):
-                attrs["root"] = defaults[name]
-                oas_operation.parameters[i].required = False
-            else:
-                oas_operation.parameters[i].required = True
+                ):
+                    oas_operation.parameters[i].required = False
 
             attr_schema = type(name, (RootModel,), attrs).model_json_schema(
                 ref_template="#/components/schemas/{model}"

--- a/tests/test_oas/bench/decorated_handler.py
+++ b/tests/test_oas/bench/decorated_handler.py
@@ -15,7 +15,7 @@ from .model import Pet
 
 @inject_params
 async def list_pet(
-    format: str = Field(...),
+    format: str = Field(..., description="description for format"),
     name: Optional[str] = None,
     *,
     promo: Optional[UUID] = Field(

--- a/tests/test_oas/bench/decorated_handler_with_request.py
+++ b/tests/test_oas/bench/decorated_handler_with_request.py
@@ -16,7 +16,7 @@ from .model import Pet
 @inject_params.and_request
 async def list_pet(
     request,
-    format: str = Field(...),
+    format: str = Field(..., description="description for format"),
     name: Optional[str] = None,
     *,
     promo: Optional[UUID] = Field(

--- a/tests/test_oas/bench/pydantic_view.py
+++ b/tests/test_oas/bench/pydantic_view.py
@@ -17,7 +17,7 @@ from .model import Pet
 class PetCollectionView(PydanticView):
     async def get(
         self,
-        format: str = Field(...),
+        format: str = Field(..., description="description for format"),
         name: Optional[str] = None,
         *,
         promo: Optional[UUID] = Field(

--- a/tests/test_oas/bench/view.py
+++ b/tests/test_oas/bench/view.py
@@ -18,7 +18,7 @@ class PetCollectionView(web.View):
     @inject_params.in_method
     async def get(
         self,
-        format: str = Field(...),
+        format: str = Field(..., description="description for format"),
         name: Optional[str] = None,
         *,
         promo: Optional[UUID] = Field(

--- a/tests/test_oas/test_view.py
+++ b/tests/test_oas/test_view.py
@@ -105,6 +105,7 @@ async def test_pets_route_should_have_get_method(generate_oas, aiohttp_client, e
                 "name": "format",
                 "required": True,
                 "schema": {"title": "format", "type": "string"},
+                "description": "description for format",
             },
             {
                 "in": "query",


### PR DESCRIPTION
Missed this problem in previous MR,
If a field is required and it has a description, the description didn't add to specification