### PR TITLE
Mark request bodies as required in the OAS

### DIFF
--- a/aiohttp_pydantic/oas/view.py
+++ b/aiohttp_pydantic/oas/view.py
@@ -206,6 +206,11 @@ def _add_http_method_to_oas(
                 "application/json": {"schema": body_ref}
             }
 
+        # A handler declaring a body argument rejects a request without one
+        # with a 400, so the body is required. Omitting the flag defaults it
+        # to false, telling generated clients the body may be left out.
+        oas_operation.request_body.required = True
+
     indexes = count()
     for args_location, args in (
         ("path", path_args.items()),

--- a/tests/test_oas/test_view.py
+++ b/tests/test_oas/test_view.py
@@ -9,6 +9,7 @@ import pytest
 from aiohttp_pydantic import PydanticView, oas
 from aiohttp_pydantic.injectors import Group
 from aiohttp_pydantic.oas.typing import r200
+from aiohttp_pydantic.uploaded_file import UploadedFile
 import aiohttp_pydantic.oas.view
 from .bench.model import Pet
 from .bench import (
@@ -193,7 +194,8 @@ async def test_pets_route_should_have_post_method(generate_oas, aiohttp_client):
         "requestBody": {
             "content": {
                 "application/json": {"schema": {"$ref": "#/components/schemas/Pet"}}
-            }
+            },
+            "required": True,
         },
         "responses": {
             "201": {
@@ -340,7 +342,8 @@ async def test_pets_id_route_should_have_put_method(generate_oas, aiohttp_client
         "requestBody": {
             "content": {
                 "application/json": {"schema": {"$ref": "#/components/schemas/Pet"}}
-            }
+            },
+            "required": True,
         },
         "responses": {"200": {"description": ""}},
     }
@@ -424,3 +427,26 @@ async def test_use_parameters_group_should_not_impact_the_oas(aiohttp_client):
     assert await ensure_content_durability(
         await aiohttp_client(app1)
     ) == await ensure_content_durability(await aiohttp_client(app2))
+
+
+async def test_multipart_body_should_be_required():
+    class UploadView(PydanticView):
+        async def post(self, document: UploadedFile) -> r200[Pet]:
+            return web.json_response()
+
+    app = web.Application()
+    app.router.add_view("/upload", UploadView)
+
+    spec = aiohttp_pydantic.oas.view.generate_oas([app])
+
+    assert spec["paths"]["/upload"]["post"]["requestBody"] == {
+        "content": {
+            "multipart/form-data": {
+                "schema": {
+                    "type": "object",
+                    "properties": {"document": {"type": "string", "format": "binary"}},
+                }
+            }
+        },
+        "required": True,
+    }


### PR DESCRIPTION
A handler that declares a body argument rejects a request without one with a 400 — `BodyGetter._inject` for a JSON body, and the `"Multipart request is required"` check for multipart. The generated document leaves `required` off `requestBody`, which OpenAPI reads as `false`, so the document says the body may be omitted.

That matters for code generated from the document. `openapi-python-client` turns the operation into `body: SessionIdRequest | Unset = UNSET`, so a caller can leave the body out, type-check clean, and get a 400 at runtime.

`RequestBody.required` already exists in `oas/struct.py` and is covered by `test_paths_operation_requestBody`. `generate_oas` never called it.

The flag is set after the multipart/JSON branch so it applies to both, and after `content` is assigned so the key order stays `content, required`.

Tests: `"required": True` added to the two expected specs in `test_oas/test_view.py`, plus `test_multipart_body_should_be_required` — the multipart branch had no OAS coverage. 184 passed, 2 skipped. `openapi_spec_validator.validate` runs over the generated specs in the parametrised tests, so the output is still valid OpenAPI 3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)